### PR TITLE
Update is_int usage with is_numeric

### DIFF
--- a/includes/shadow-taxonomy.php
+++ b/includes/shadow-taxonomy.php
@@ -210,7 +210,7 @@ function get_associated_term_id( $post, $taxonomy ) {
  */
 function get_associated_term( $post, $taxonomy ) {
 
-	if ( is_int( $post ) ) {
+	if ( is_numeric( $post ) ) {
 		$post = get_post( $post );
 	}
 


### PR DESCRIPTION
`is_int` returns false for string int values, get_associated_term_id expects passed data to be WP_Post object which fails in case of string int.